### PR TITLE
Use a station URN when name is absent

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+Version 1.1.1
+
+* Fix misaligned table index when station name is absent in `collector2table`.
+
 Version 1.1.0
 
 * Use retrying to access SOS servers.

--- a/ioos_tools/ioos.py
+++ b/ioos_tools/ioos.py
@@ -395,10 +395,14 @@ def collector2table(collector, config, col='sea_water_temperature (C)'):
         df.update({station: g.get_group(station).iloc[0]})
     df = pd.DataFrame.from_dict(df).T
 
+    station_dict = {}
+    for offering in c.server.offerings:
+        station_dict.update({offering.name: offering.description})
+
     names = []
     for sta in df.index:
-        names.extend([offering.description for offering in
-                      c.server.offerings if sta == offering.name])
+        names.append(station_dict.get(sta, sta))
+
     df['name'] = names
 
     observations = []


### PR DESCRIPTION
@jbosch-noaa this PR should fix the issue I found today with https://github.com/ioos/notebooks_demos/issues/277, not sure if there are more.