### PR TITLE
use timeout decorator in is_station

### DIFF
--- a/ioos_tools/ioos.py
+++ b/ioos_tools/ioos.py
@@ -22,6 +22,7 @@ from contextlib import contextmanager
 from lxml import etree
 from owslib import fes
 from owslib.ows import ExceptionReport
+import timeout_decorator
 
 from .tardis import cube2series
 
@@ -565,6 +566,7 @@ def get_model_name(url):
     return mod_name
 
 
+@timeout_decorator.timeout(10, use_signals=False)
 def is_station(url):
     from netCDF4 import Dataset
     with Dataset(url) as nc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests
 retrying
 scikit-learn
 scipy
+timeout-decorator


### PR DESCRIPTION
Some URLs, like http://thredds.secoora.org/thredds/dodsC/G1_SST_GLOBAL.nc.html, are really slow to respond and we need to finish some notebooks before Travis-CI times out.

Ping @kwilcox: is there something we can do to make accessing `G1_SST_GLOBAL` a little faster?